### PR TITLE
Check for empty weather data

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	
 	"github.com/evogelsa/DCS-real-weather/miz"
 	"github.com/evogelsa/DCS-real-weather/util"
 	"github.com/evogelsa/DCS-real-weather/weather"
@@ -17,14 +19,22 @@ func main() {
 	_, err := miz.Unzip()
 	util.Must(err)
 
-	// update mission file with weather data
-	miz.Update(data)
-
+	if data.WeatherDatas > 0 {
+		if int(data.Data[0].Barometer.Hg*25.4 + .5) > 0 {
+			// update mission file with weather data
+			miz.Update(data)
+		} else {
+			log.Println("Incorrect weather data. No real weather applied to mission file.")
+		}
+	}
+	
 	// repack mission file contents and form realweather.miz output
 	miz.Zip()
 
 	// remove unpacked contents from directory
 	miz.Clean()
 
-	weather.LogMETAR(data)
+	if data.WeatherDatas > 0 {
+		weather.LogMETAR(data) 
+	}
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"log"
-	
+
 	"github.com/evogelsa/DCS-real-weather/miz"
 	"github.com/evogelsa/DCS-real-weather/util"
 	"github.com/evogelsa/DCS-real-weather/weather"
@@ -13,21 +13,28 @@ func main() {
 	util.ParseConfig()
 
 	// get METAR report
-	data := weather.GetWeather()
+	var err error
+	var data weather.WeatherData
+	data, err = weather.GetWeather()
+	if err != nil {
+		log.Printf("Error getting weather, using default: %v\n", err)
+		data = weather.DefaultWeather
+	}
 
 	// unzip mission file
-	_, err := miz.Unzip()
-	util.Must(err)
-
-	if data.WeatherDatas > 0 {
-		if int(data.Data[0].Barometer.Hg*25.4 + .5) > 0 {
-			// update mission file with weather data
-			miz.Update(data)
-		} else {
-			log.Println("Incorrect weather data. No real weather applied to mission file.")
-		}
+	_, err = miz.Unzip()
+	if err != nil {
+		log.Fatalf("Error unzipping mission file: %v\n", err)
 	}
-	
+
+	// sanity check data before updating mission
+	if data.WeatherDatas > 0 && data.Data[0].Barometer.Hg > 0 {
+		// update mission file with weather data
+		miz.Update(data)
+	} else {
+		log.Println("Incorrect weather data. No real weather applied to mission file.")
+	}
+
 	// repack mission file contents and form realweather.miz output
 	miz.Zip()
 
@@ -35,6 +42,6 @@ func main() {
 	miz.Clean()
 
 	if data.WeatherDatas > 0 {
-		weather.LogMETAR(data) 
+		weather.LogMETAR(data)
 	}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -16,13 +16,6 @@ func Clamp(v, min, max float64) float64 {
 	return v
 }
 
-// Must panics on error
-func Must(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 // Configuration is the structure of config.json to be parsed
 type Configuration struct {
 	APIKey        string        `json:"api-key"`
@@ -41,17 +34,28 @@ type Configuration struct {
 func ParseConfig() {
 	var config Configuration
 	file, err := os.Open("config.json")
-	Must(err)
+	if err != nil {
+		log.Fatalf("Error opening config.json: %v\n", err)
+	}
+
 	defer file.Close()
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(&config)
-	Must(err)
+	if err != nil {
+		log.Fatalf("Error decoding config.json: %v\n", err)
+	}
 
 	Config = config
 
 	if Config.Logfile != "" {
-		f, err := os.OpenFile(Config.Logfile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-		Must(err)
+		f, err := os.OpenFile(
+			Config.Logfile,
+			os.O_WRONLY|os.O_CREATE|os.O_APPEND,
+			0644,
+		)
+		if err != nil {
+			log.Printf("Error opening logfile: %v\n", err)
+		}
 		// defer f.Close()
 
 		mw := io.MultiWriter(os.Stdout, f)


### PR DESCRIPTION
It can rarely happen that CheckWX is down and/or transmits corrupted weather data (for example, QNH == 0). Should it happen so, RW still goes on modifying the mission file, DCS will load the .miz file by RW but clients will crash when entering the slot. 

Commit should avoid that, in these cases, RW will create a miz file with corrupt weather data. RW will still create a realweather.miz file (only because of batch file purposes), but the realweather.miz file should be unmodified with respect to the original mission.miz file.