### PR TITLE
Fix RW breaking miz file with quotes in triggers

### DIFF
--- a/miz/miz.go
+++ b/miz/miz.go
@@ -49,16 +49,6 @@ func Update(data weather.WeatherData) error {
 		return fmt.Errorf("Error writing mission file: %v", err)
 	}
 
-	b, err := os.ReadFile("mission_unpacked/mission")
-	if err != nil {
-		return fmt.Errorf("Error reading unpacked mission: %v", err)
-	}
-
-	err = os.WriteFile("mission_unpacked/mission", b, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("Error writing mission file: %v", err)
-	}
-
 	return nil
 }
 

--- a/miz/miz.go
+++ b/miz/miz.go
@@ -54,7 +54,6 @@ func Update(data weather.WeatherData) error {
 		return fmt.Errorf("Error reading unpacked mission: %v", err)
 	}
 	s := string(b)
-	s = strings.ReplaceAll(s, `\\\`, "")
 
 	err = os.WriteFile("mission_unpacked/mission", []byte(s), os.ModePerm)
 	if err != nil {

--- a/miz/miz.go
+++ b/miz/miz.go
@@ -53,9 +53,8 @@ func Update(data weather.WeatherData) error {
 	if err != nil {
 		return fmt.Errorf("Error reading unpacked mission: %v", err)
 	}
-	s := string(b)
 
-	err = os.WriteFile("mission_unpacked/mission", []byte(s), os.ModePerm)
+	err = os.WriteFile("mission_unpacked/mission", b, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("Error writing mission file: %v", err)
 	}


### PR DESCRIPTION
When triggers in miz file has quotes and therefore unpacked mission file contains escaped characters, RW corrupts mission by removing them.

For example, this line in unpacked original mission file:

[2] = "a_do_script(\"assert(loadfile(lfs.writedir() .. \\\"13GVV OAS\\\\\\\\Scripts\\\\\\\\scriptLoader.lua\\\"))()\"); mission.trig.func[2]=nil;",

becomes like this after being rewritten by RW:

[2] = "a_do_script(\"assert(loadfile(lfs.writedir() .. "13GVV OAS\\Scripts\\scriptLoader.lua"))()\"); mission.trig.func[2]=nil;",

Miz file is then corrupted and DCS refuses to load it.